### PR TITLE
Prevent attempt to access attribute of null TimeMap, causing crash on Android 4.4.X

### DIFF
--- a/app/src/main/java/org/mitre/mobilememento/TimeMap.java
+++ b/app/src/main/java/org/mitre/mobilememento/TimeMap.java
@@ -30,7 +30,7 @@ public class TimeMap implements Comparator<Memento> {
     private TimeMap(TimeMap... others) {
         this.screenType = ScreenType.DESKTOP;
         if (others.length != 0) {
-            this.contentUrl = others[0].contentUrl;
+            if(others[0] != null)   this.contentUrl = others[0].contentUrl; // Prevent accessor to invalid TM object
             for (TimeMap map : others) if (map != null) mementos.addAll(map.getMementos());
         }
     }


### PR DESCRIPTION
@jbrunelle @Thing342 
